### PR TITLE
fix: silentgear full compability

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/needs_allthemodium_tool.json
+++ b/src/generated/resources/data/forge/tags/blocks/needs_allthemodium_tool.json
@@ -1,7 +1,0 @@
-{
-  "values": [
-    "allthemodium:vibranium_ore",
-    "allthemodium:other_vibranium_ore",
-    "allthemodium:unobtainium_ore"
-  ]
-}

--- a/src/generated/resources/data/forge/tags/blocks/needs_netherite_tool.json
+++ b/src/generated/resources/data/forge/tags/blocks/needs_netherite_tool.json
@@ -1,6 +1,9 @@
 {
   "values": [
     "allthemodium:allthemodium_ore",
-    "allthemodium:allthemodium_slate_ore"
+    "allthemodium:allthemodium_slate_ore",
+    "allthemodium:vibranium_ore",
+    "allthemodium:other_vibranium_ore",
+    "allthemodium:unobtainium_ore"
   ]
 }

--- a/src/main/java/com/thevortex/allthemodium/datagen/server/BlockTags.java
+++ b/src/main/java/com/thevortex/allthemodium/datagen/server/BlockTags.java
@@ -86,10 +86,14 @@ public class BlockTags extends BlockTagsProvider {
 
         tag(NEEDS_NETHERITE_TOOL).add(ModRegistry.ALLTHEMODIUM_ORE.get());
         tag(NEEDS_NETHERITE_TOOL).add(ModRegistry.ALLTHEMODIUM_SLATE_ORE.get());
+        // Silent gear doesn't support higher tiers like this.
+        tag(NEEDS_NETHERITE_TOOL).add(ModRegistry.VIBRANIUM_ORE.get());
+        tag(NEEDS_NETHERITE_TOOL).add(ModRegistry.OTHER_VIBRANIUM_ORE.get());
+        tag(NEEDS_NETHERITE_TOOL).add(ModRegistry.UNOBTAINIUM_ORE.get());
+        // Mining the above blocks with netherite will take a lot longer but this is for support of SG.
         tag(TagRegistry.NEEDS_ALLTHEMODIUM_TOOL).add(ModRegistry.VIBRANIUM_ORE.get());
         tag(TagRegistry.NEEDS_ALLTHEMODIUM_TOOL).add(ModRegistry.OTHER_VIBRANIUM_ORE.get());
-        tag(TagRegistry.NEEDS_ALLTHEMODIUM_TOOL).add(ModRegistry.UNOBTAINIUM_ORE.get());
-
+        tag(TagRegistry.NEEDS_VIBRANIUM_TOOL).add(ModRegistry.UNOBTAINIUM_ORE.get());
 
         tag(net.minecraft.tags.BlockTags.MINEABLE_WITH_AXE).add(ModRegistry.DEMONIC_PLANKS.get());
         tag(net.minecraft.tags.BlockTags.MINEABLE_WITH_AXE).add(ModRegistry.DEMONIC_LOG.get());

--- a/src/main/resources/data/silentgear/silentgear_materials/allthemodium.json
+++ b/src/main/resources/data/silentgear/silentgear_materials/allthemodium.json
@@ -1,8 +1,12 @@
 {
   "availability": {
-    "tier": 5,
+    "tier": 4,
+    "categories": [
+      "metal"
+    ],
     "visible": true,
-    "gear_blacklist": []
+    "gear_blacklist": [],
+    "can_salvage": true
   },
   "crafting_items": {
     "main": {
@@ -17,7 +21,7 @@
       "durability": 6000.0,
       "armor_durability": 750.0,
       "enchantment_value": 40.0,
-      "harvest_level": 5.0,
+      "harvest_level": 4.0,
       "harvest_speed": 18.0,
       "melee_damage": 105.0,
       "magic_damage": 32.0,
@@ -97,6 +101,53 @@
       {
         "name": "silentgear:soft",
         "level": 3
+      }
+    ]
+  },
+  "model": {
+    "main/all": [
+      {
+        "texture": "silentgear:main_generic_hc",
+        "color": "#ffef0e"
+      },
+      {
+        "texture": "silentgear:_highlight"
+      }
+    ],
+    "main/fragment": [
+      {
+        "texture": "silentgear:metal",
+        "color": "#ffef0e"
+      }
+    ],
+    "rod/all": [
+      {
+        "texture": "silentgear:rod_generic_lc",
+        "color": "#ffef0e"
+      }
+    ],
+    "rod/part": [
+      {
+        "texture": "silentgear:rod",
+        "color": "#ffef0e"
+      }
+    ],
+    "tip/all": [
+      {
+        "texture": "silentgear:tip_sharp",
+        "color": "#ffef0e"
+      }
+    ],
+    "tip/part": [
+      {
+        "texture": "silentgear:tip_base"
+      },
+      {
+        "texture": "silentgear:tip",
+        "color": "#ffef0e"
+      },
+      {
+        "texture": "silentgear:tip_shine"
       }
     ]
   }

--- a/src/main/resources/data/silentgear/silentgear_materials/unobtainium.json
+++ b/src/main/resources/data/silentgear/silentgear_materials/unobtainium.json
@@ -1,8 +1,12 @@
 {
   "availability": {
-    "tier": 7,
+    "tier": 5,
+    "categories": [
+      "metal"
+    ],
     "visible": true,
-    "gear_blacklist": []
+    "gear_blacklist": [],
+    "can_salvage": true
   },
   "crafting_items": {
     "main": {
@@ -17,7 +21,7 @@
       "durability": 10000.0,
       "armor_durability": 2000.0,
       "enchantment_value": 60.0,
-      "harvest_level": 7.0,
+      "harvest_level": 4.0,
       "harvest_speed": 48.0,
       "melee_damage": 233.0,
       "magic_damage": 65.0,
@@ -97,6 +101,53 @@
       {
         "name": "silentgear:hard",
         "level": 7
+      }
+    ]
+  },
+  "model": {
+    "main/all": [
+      {
+        "texture": "silentgear:main_generic_hc",
+        "color": "#d152e3"
+      },
+      {
+        "texture": "silentgear:_highlight"
+      }
+    ],
+    "main/fragment": [
+      {
+        "texture": "silentgear:metal",
+        "color": "#d152e3"
+      }
+    ],
+    "rod/all": [
+      {
+        "texture": "silentgear:rod_generic_lc",
+        "color": "#d152e3"
+      }
+    ],
+    "rod/part": [
+      {
+        "texture": "silentgear:rod",
+        "color": "#d152e3"
+      }
+    ],
+    "tip/all": [
+      {
+        "texture": "silentgear:tip_sharp",
+        "color": "#d152e3"
+      }
+    ],
+    "tip/part": [
+      {
+        "texture": "silentgear:tip_base"
+      },
+      {
+        "texture": "silentgear:tip",
+        "color": "#d152e3"
+      },
+      {
+        "texture": "silentgear:tip_shine"
       }
     ]
   }

--- a/src/main/resources/data/silentgear/silentgear_materials/vibranium.json
+++ b/src/main/resources/data/silentgear/silentgear_materials/vibranium.json
@@ -1,8 +1,12 @@
 {
   "availability": {
-    "tier": 6,
+    "tier": 4,
+    "categories": [
+      "metal"
+    ],
     "visible": true,
-    "gear_blacklist": []
+    "gear_blacklist": [],
+    "can_salvage": true
   },
   "crafting_items": {
     "main": {
@@ -17,7 +21,7 @@
       "durability": 5500.0,
       "armor_durability": 1000.0,
       "enchantment_value": 45.0,
-      "harvest_level": 6.0,
+      "harvest_level": 4.0,
       "harvest_speed": 28.0,
       "melee_damage": 85.0,
       "magic_damage": 47.0,
@@ -97,6 +101,53 @@
       {
         "name": "silentgear:hard",
         "level": 6
+      }
+    ]
+  },
+  "model": {
+    "main/all": [
+      {
+        "texture": "silentgear:main_generic_hc",
+        "color": "#26de88"
+      },
+      {
+        "texture": "silentgear:_highlight"
+      }
+    ],
+    "main/fragment": [
+      {
+        "texture": "silentgear:metal",
+        "color": "#26de88"
+      }
+    ],
+    "rod/all": [
+      {
+        "texture": "silentgear:rod_generic_lc",
+        "color": "#26de88"
+      }
+    ],
+    "rod/part": [
+      {
+        "texture": "silentgear:rod",
+        "color": "#26de88"
+      }
+    ],
+    "tip/all": [
+      {
+        "texture": "silentgear:tip_sharp",
+        "color": "#26de88"
+      }
+    ],
+    "tip/part": [
+      {
+        "texture": "silentgear:tip_base"
+      },
+      {
+        "texture": "silentgear:tip",
+        "color": "#26de88"
+      },
+      {
+        "texture": "silentgear:tip_shine"
       }
     ]
   }


### PR DESCRIPTION
All items now share a global harvest tier grade, to share compatibility with silent gear. Meaning, allthemodium, vibranium and unobtainium can be collected using netherite tools. The process for doing so is cumbersome but makes sense. "Vanilla" tools build from the three aforementioned materials work exactly like they did before they were removed. The only difference is some tags were added that allow silent gear to treat them as proper tools.

Also now supporting colors in silent gear, allthemodium, vibranium and unobtainium tools and armor are now salvageable as well.